### PR TITLE
build fail bug

### DIFF
--- a/src/components/RestaurantFinder.tsx
+++ b/src/components/RestaurantFinder.tsx
@@ -34,7 +34,7 @@ const RestaurantFinder = () => {
     updateFilters,
   } = useRestaurants()
   
-  const { session, error: sessionError, loadSessionById, getAllVotes, setSession, createSession, getSessionUrl } = useVotingContext()
+  const { session, error: sessionError, getAllVotes, setSession, createSession, getSessionUrl } = useVotingContext()
   const [addingRestaurant, setAddingRestaurant] = useState(false)
   const [addError, setAddError] = useState<string | null>(null)
   const [showCopyMessage, setShowCopyMessage] = useState(false)


### PR DESCRIPTION
This change removes the unused loadSessionById variable from the destructured useVotingContext hook in the RestaurantFinder component. This should fix the TypeScript error that was causing the build to fail.