### PR TITLE
Session bugfix

### DIFF
--- a/src/hooks/useVoting.ts
+++ b/src/hooks/useVoting.ts
@@ -99,7 +99,7 @@ export const useVoting = () => {
     };
     
     loadSessionFromUrl();
-  }, []); // Only run once on initialization
+  }, [window.location.search]); // Re-run when URL search params change
 
   // Create a new session
   const createSession = async (name: string = 'New Session') => {


### PR DESCRIPTION
The useEffect hook now watches for changes to window.location.search When the URL changes (like when opening a shared link), it will re-run the effect This should properly load the session when opening the shared link in a new browser