### PR TITLE
Places API depreciation issue

### DIFF
--- a/src/components/AddressInput.tsx
+++ b/src/components/AddressInput.tsx
@@ -15,8 +15,8 @@ export const AddressInput: React.FC = () => {
   const { setLocation, isLoading, error } = useLocation();
   const [address, setAddress] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const autocompleteRef = useRef<HTMLInputElement>(null);
-  const autocompleteInstance = useRef<any>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const autocompleteRef = useRef<any>(null);
 
   useEffect(() => {
     // Load the Google Places API script
@@ -34,17 +34,19 @@ export const AddressInput: React.FC = () => {
   }, []);
 
   const initializeAutocomplete = () => {
-    if (autocompleteRef.current && window.google) {
-      autocompleteInstance.current = new window.google.maps.places.Autocomplete(
-        autocompleteRef.current,
-        {
-          types: ['address'],
-          componentRestrictions: { country: 'us' },
-        }
-      );
+    if (inputRef.current && window.google) {
+      // Create the PlaceAutocompleteElement
+      const autocomplete = new window.google.maps.places.PlaceAutocompleteElement({
+        inputElement: inputRef.current,
+        componentRestrictions: { country: 'us' },
+      });
 
-      autocompleteInstance.current.addListener('place_changed', () => {
-        const place = autocompleteInstance.current.getPlace();
+      // Store the autocomplete instance
+      autocompleteRef.current = autocomplete;
+
+      // Add event listener for place selection
+      autocomplete.addListener('place_changed', () => {
+        const place = autocomplete.getPlace();
         if (place.geometry) {
           setAddress(place.formatted_address);
         }
@@ -84,7 +86,7 @@ export const AddressInput: React.FC = () => {
   return (
     <Box component="form" onSubmit={handleSubmit} sx={{ width: '100%', maxWidth: 400 }}>
       <TextField
-        inputRef={autocompleteRef}
+        inputRef={inputRef}
         fullWidth
         label="Enter your address"
         variant="outlined"


### PR DESCRIPTION
js?key=undefined&libraries=places:68 As of March 1st, 2025, google.maps.places.Autocomplete is not available to new customers. Please use google.maps.places.PlaceAutocompleteElement instead. At this time, google.maps.places.Autocomplete is not scheduled to be discontinued, but google.maps.places.PlaceAutocompleteElement is recommended over google.maps.places.Autocomplete. While google.maps.places.Autocomplete will continue to receive bug fixes for any major regressions, existing bugs in google.maps.places.Autocomplete will not be addressed. At least 12 months notice will be given before support is discontinued. Please see https://developers.google.com/maps/legacy for additional details and https://developers.google.com/maps/documentation/javascript/places-migration-overview for the migration guide.