### PR TITLE
Add Google OAuth env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,5 @@
 
 # API URL
 VITE_API_URL=https://api.fork-it.cc
+# Google OAuth client ID
 VITE_GOOGLE_CLIENT_ID=

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A fun web application that helps indecisive office workers figure out where to g
    npm install
    ```
 
-3. Create a `.env` file in the root directory with the API URL and Google OAuth client ID:
+3. Copy `.env.example` to `.env` and set the API URL and Google OAuth client ID:
    ```
    VITE_API_URL=https://api.fork-it.cc
    VITE_GOOGLE_CLIENT_ID=YOUR_GOOGLE_CLIENT_ID

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -17,6 +17,7 @@ const AuthContext = createContext<AuthContextProps | undefined>(undefined);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
+  const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
 
   useEffect(() => {
     const saved = localStorage.getItem('user');
@@ -51,7 +52,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   };
 
   return (
-    <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+    <GoogleOAuthProvider clientId={googleClientId}>
       <AuthContext.Provider value={{ user, loginWithGoogle, logout, registerManual }}>
         {children}
       </AuthContext.Provider>


### PR DESCRIPTION
## Summary
- document Google OAuth client ID env var in `.env.example`
- read the client ID from `import.meta.env` in `AuthContext`
- mention the client ID in README setup instructions

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a7924da88322bd162839c5e02bcb