### PR TITLE
Fix Google login by updating CSP

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -3,7 +3,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(self)
-  Content-Security-Policy: default-src 'self' https://maps.googleapis.com https://*.googleapis.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://maps.googleapis.com https://*.googleapis.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.googleapis.com https://*.gstatic.com; connect-src 'self' https://*.googleapis.com https://api.fork-it.cc
+  Content-Security-Policy: default-src 'self' https://maps.googleapis.com https://*.googleapis.com https://accounts.google.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://maps.googleapis.com https://*.googleapis.com https://accounts.google.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.googleapis.com https://*.gstatic.com; connect-src 'self' https://*.googleapis.com https://accounts.google.com https://api.fork-it.cc
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable 


### PR DESCRIPTION
## Summary
- update content security policy to allow `https://accounts.google.com` scripts and connections

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845b7fe9a3883228d2ba98d393d5877