### PR TITLE
Add user profile display and custom list

### DIFF
--- a/src/components/CustomListCreator.tsx
+++ b/src/components/CustomListCreator.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+import { Box, Paper, Typography, TextField, Button, Chip } from '@mui/material'
+import { Restaurant } from '../types'
+import { useSession } from '../hooks/useSession'
+
+export default function CustomListCreator() {
+  const [restaurantName, setRestaurantName] = useState('')
+  const [list, setList] = useState<Restaurant[]>([])
+  const [randomPick, setRandomPick] = useState<Restaurant | null>(null)
+  const { createSession } = useSession()
+
+  const addRestaurant = () => {
+    if (!restaurantName.trim()) return
+    const newRestaurant: Restaurant = {
+      id: crypto.randomUUID(),
+      name: restaurantName.trim(),
+      vicinity: '',
+      rating: 0,
+      user_ratings_total: 0,
+      price_level: 0,
+      geometry: { location: { lat: 0, lng: 0 } },
+      types: ['restaurant']
+    }
+    setList(prev => [...prev, newRestaurant])
+    setRestaurantName('')
+  }
+
+  const removeRestaurant = (id: string) => {
+    setList(prev => prev.filter(r => r.id !== id))
+  }
+
+  const pickRandom = () => {
+    if (list.length === 0) return
+    const idx = Math.floor(Math.random() * list.length)
+    setRandomPick(list[idx])
+  }
+
+  const startSession = async () => {
+    if (list.length === 0) return
+    await createSession('Lunch List', list)
+  }
+
+  return (
+    <Paper sx={{ p: 2, mb: 2 }}>
+      <Typography variant="h6" gutterBottom>
+        Create Custom Restaurant List
+      </Typography>
+      <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
+        <TextField
+          label="Restaurant Name"
+          value={restaurantName}
+          onChange={e => setRestaurantName(e.target.value)}
+          fullWidth
+        />
+        <Button variant="contained" onClick={addRestaurant}>Add</Button>
+      </Box>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
+        {list.map(item => (
+          <Chip key={item.id} label={item.name} onDelete={() => removeRestaurant(item.id)} />
+        ))}
+      </Box>
+      <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
+        <Button variant="outlined" onClick={pickRandom}>Pick Random</Button>
+        <Button variant="contained" onClick={startSession}>Start Voting Session</Button>
+      </Box>
+      {randomPick && (
+        <Typography variant="body1">Today's pick: {randomPick.name}</Typography>
+      )}
+    </Paper>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,10 @@
-import { Box, Typography, IconButton, useTheme } from '@mui/material'
+import { Box, Typography, IconButton, useTheme, Button } from '@mui/material'
 import {
   Brightness4 as DarkModeIcon,
   Brightness7 as LightModeIcon,
 } from '@mui/icons-material'
 import { motion } from 'framer-motion'
+import { useAuth } from '../contexts/AuthContext'
 
 interface HeaderProps {
   mode: 'light' | 'dark';
@@ -12,6 +13,7 @@ interface HeaderProps {
 
 const Header = ({ mode, onToggleColorMode }: HeaderProps) => {
   const theme = useTheme()
+  const { user, logout } = useAuth()
 
   return (
     <Box
@@ -55,20 +57,32 @@ const Header = ({ mode, onToggleColorMode }: HeaderProps) => {
         </Typography>
       </Box>
 
-      <IconButton
-        onClick={onToggleColorMode}
-        color="inherit"
-        sx={{
-          transition: 'transform 0.2s',
-          '&:hover': {
-            transform: 'scale(1.1)',
-          },
-        }}
-      >
-        {mode === 'dark' ? <LightModeIcon /> : <DarkModeIcon />}
-      </IconButton>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        {user && (
+          <Typography variant="body1" sx={{ mr: 1 }}>
+            Hello, {user.name}
+          </Typography>
+        )}
+        <IconButton
+          onClick={onToggleColorMode}
+          color="inherit"
+          sx={{
+            transition: 'transform 0.2s',
+            '&:hover': {
+              transform: 'scale(1.1)',
+            },
+          }}
+        >
+          {mode === 'dark' ? <LightModeIcon /> : <DarkModeIcon />}
+        </IconButton>
+        {user && (
+          <Button onClick={logout} variant="outlined" size="small">
+            Logout
+          </Button>
+        )}
+      </Box>
     </Box>
   )
 }
 
-export default Header 
+export default Header

--- a/src/components/RestaurantFinder.tsx
+++ b/src/components/RestaurantFinder.tsx
@@ -9,6 +9,7 @@ import { Restaurant } from '../types/Restaurant'
 import { useFilters } from '../hooks/useFilters'
 import { useSession } from '../hooks/useSession'
 import { ResultsChart } from './ResultsChart'
+import CustomListCreator from './CustomListCreator'
 import { useDebounce } from '../hooks/useDebounce'
 
 export const RestaurantFinder = () => {
@@ -142,6 +143,7 @@ export const RestaurantFinder = () => {
 
   return (
     <div>
+      <CustomListCreator />
       <Paper sx={{ p: 2, m: 2 }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           {isSessionLoading ? (


### PR DESCRIPTION
## Summary
- display the logged in user and logout option in the header
- allow creating a custom list of restaurants with random pick
- integrate custom list component with restaurant finder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845c49bb9ac83229a0c68c1a1775834