### PR TITLE
Add minimal voting feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,12 @@ import { useState } from 'react'
 import { ThemeProvider, CssBaseline, Box } from '@mui/material'
 import { lightTheme, darkTheme } from './theme'
 import Header from './components/Header'
-import GroupSession from './components/GroupSession'
-import { RestaurantFinder } from './components/RestaurantFinder'
 import LoginPage from './components/LoginPage'
 import { useAuth } from './contexts/AuthContext'
+import { Routes, Route } from 'react-router-dom'
+import Profile from './pages/Profile'
+import LunchOptions from './pages/LunchOptions'
+import VotePage from './pages/VotePage'
 
 export default function App() {
   const [mode, setMode] = useState<'light' | 'dark'>('light')
@@ -20,14 +22,22 @@ export default function App() {
       <CssBaseline />
       <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
         <Header mode={mode} onToggleColorMode={toggleColorMode} />
-        {user ? (
-          <>
-            <GroupSession />
-            <RestaurantFinder />
-          </>
-        ) : (
-          <LoginPage />
-        )}
+        <Routes>
+          <Route path="/vote/:sessionId" element={<VotePage />} />
+          {user ? (
+            <Route
+              path="/"
+              element={
+                <>
+                  <Profile />
+                  <LunchOptions />
+                </>
+              }
+            />
+          ) : (
+            <Route path="/" element={<LoginPage />} />
+          )}
+        </Routes>
       </Box>
     </ThemeProvider>
   )

--- a/src/pages/LunchOptions.tsx
+++ b/src/pages/LunchOptions.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react'
+import { Box, Button, TextField, List, ListItem, IconButton } from '@mui/material'
+import DeleteIcon from '@mui/icons-material/Delete'
+import EditIcon from '@mui/icons-material/Edit'
+import { createSession, getOptions, addOption, updateOption, deleteOption } from '../services/optionsApi'
+
+interface Option { id: string; name: string }
+
+export default function LunchOptions() {
+  const [options, setOptions] = useState<Option[]>([])
+  const [newName, setNewName] = useState('')
+  const [link, setLink] = useState('')
+  const [editing, setEditing] = useState<{id:string,name:string}|null>(null)
+
+  const load = async () => {
+    setOptions(await getOptions())
+  }
+
+  useEffect(() => { load() }, [])
+
+  const handleAdd = async () => {
+    if (!newName) return
+    await addOption(newName)
+    setNewName('')
+    load()
+  }
+
+  const handleUpdate = async () => {
+    if (!editing) return
+    await updateOption(editing.id, editing.name)
+    setEditing(null)
+    load()
+  }
+
+  const handleDelete = async (id: string) => {
+    await deleteOption(id)
+    load()
+  }
+
+  const startSession = async () => {
+    const session = await createSession()
+    setLink(`${window.location.origin}/vote/${session.id}`)
+  }
+
+  return (
+    <Box sx={{ p:2 }}>
+      <Box sx={{ display:'flex', gap:1, mb:2 }}>
+        {editing ? (
+          <>
+            <TextField value={editing.name} onChange={e=>setEditing({...editing,name:e.target.value})} />
+            <Button onClick={handleUpdate}>Save</Button>
+            <Button onClick={()=>setEditing(null)}>Cancel</Button>
+          </>
+        ) : (
+          <>
+            <TextField value={newName} onChange={e=>setNewName(e.target.value)} label="Add option" />
+            <Button onClick={handleAdd}>Add</Button>
+          </>
+        )}
+      </Box>
+      <List>
+        {options.map(o => (
+          <ListItem key={o.id} secondaryAction={
+            <>
+              <IconButton edge="end" onClick={()=>setEditing(o)}><EditIcon /></IconButton>
+              <IconButton edge="end" onClick={()=>handleDelete(o.id)}><DeleteIcon /></IconButton>
+            </>
+          }>
+            {o.name}
+          </ListItem>
+        ))}
+      </List>
+      <Button variant="contained" onClick={startSession}>Create Voting Link</Button>
+      {link && <Box sx={{ mt:2 }}><a href={link}>{link}</a></Box>}
+    </Box>
+  )
+}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,14 @@
+import { Box, Typography, Button } from '@mui/material'
+import { useAuth } from '../contexts/AuthContext'
+
+export default function Profile() {
+  const { user, logout } = useAuth()
+  if (!user) return null
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="h6" gutterBottom>Profile</Typography>
+      <Typography>Email: {user.email}</Typography>
+      <Button variant="outlined" sx={{ mt: 2 }} onClick={logout}>Logout</Button>
+    </Box>
+  )
+}

--- a/src/pages/VotePage.tsx
+++ b/src/pages/VotePage.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+import { Box, Button, List, ListItem, Typography } from '@mui/material'
+import { useParams } from 'react-router-dom'
+import { getOptions, vote, getResults } from '../services/optionsApi'
+
+interface Option { id: string; name: string }
+
+export default function VotePage() {
+  const { sessionId } = useParams<{ sessionId: string }>()
+  const [options, setOptions] = useState<Option[]>([])
+  const [results, setResults] = useState<Record<string, number>>({})
+  const [voted, setVoted] = useState(false)
+  const userId = ((): string => {
+    const existing = localStorage.getItem('voteUserId')
+    if (existing) return existing
+    const id = crypto.randomUUID()
+    localStorage.setItem('voteUserId', id)
+    return id
+  })()
+
+  useEffect(() => {
+    getOptions().then(setOptions)
+    const load = async () => {
+      if (sessionId) setResults(await getResults(sessionId))
+    }
+    load()
+    const int = setInterval(load, 5000)
+    return () => clearInterval(int)
+  }, [sessionId])
+
+  const handleVote = async (optionId: string) => {
+    if (!sessionId || voted) return
+    const res = await vote(sessionId, optionId, userId)
+    if (!('error' in res)) {
+      setVoted(true)
+      setResults(res.votes || {})
+      localStorage.setItem('voted:' + sessionId, 'true')
+    }
+  }
+
+  return (
+    <Box sx={{ p:2 }}>
+      <Typography variant="h6" gutterBottom>Vote for lunch</Typography>
+      <List>
+        {options.map(o => (
+          <ListItem key={o.id}>
+            <Button variant="outlined" onClick={()=>handleVote(o.id)} disabled={voted}>{o.name}</Button>
+            <Box sx={{ ml:2 }}>{results[o.id] || 0}</Box>
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  )
+}

--- a/src/services/optionsApi.ts
+++ b/src/services/optionsApi.ts
@@ -1,0 +1,48 @@
+const API_BASE = import.meta.env.VITE_API_URL || 'https://api.fork-it.cc'
+
+export async function getOptions() {
+  const res = await fetch(`${API_BASE}/options`)
+  return res.json()
+}
+
+export async function addOption(name: string) {
+  const res = await fetch(`${API_BASE}/options`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name })
+  })
+  return res.json()
+}
+
+export async function updateOption(id: string, name: string) {
+  const res = await fetch(`${API_BASE}/options/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name })
+  })
+  return res.json()
+}
+
+export async function deleteOption(id: string) {
+  const res = await fetch(`${API_BASE}/options/${id}`, { method: 'DELETE' })
+  return res.json()
+}
+
+export async function createSession() {
+  const res = await fetch(`${API_BASE}/sessions`, { method: 'POST' })
+  return res.json()
+}
+
+export async function vote(sessionId: string, optionId: string, userId: string) {
+  const res = await fetch(`${API_BASE}/sessions/${sessionId}/vote`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ optionId, userId })
+  })
+  return res.json()
+}
+
+export async function getResults(sessionId: string) {
+  const res = await fetch(`${API_BASE}/sessions/${sessionId}/results`)
+  return res.json()
+}

--- a/workers/voting-api.mjs
+++ b/workers/voting-api.mjs
@@ -1,0 +1,99 @@
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const { pathname } = url;
+    const kv = env.SESSIONS_KV;
+    const cors = {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type'
+    };
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { headers: cors });
+    }
+
+    async function jsonResponse(data, init = {}) {
+      return new Response(JSON.stringify(data), {
+        headers: { 'Content-Type': 'application/json', ...cors },
+        ...init
+      });
+    }
+
+    // Helper to get and parse options list
+    async function getOptions() {
+      const raw = await kv.get('options');
+      return raw ? JSON.parse(raw) : [];
+    }
+
+    // Routes
+    try {
+      if (pathname === '/options' && request.method === 'GET') {
+        const options = await getOptions();
+        return jsonResponse(options);
+      }
+
+      if (pathname === '/options' && request.method === 'POST') {
+        const { name } = await request.json();
+        if (!name) return jsonResponse({ error: 'Name required' }, { status: 400 });
+        const options = await getOptions();
+        const option = { id: crypto.randomUUID(), name };
+        options.push(option);
+        await kv.put('options', JSON.stringify(options));
+        return jsonResponse(option, { status: 201 });
+      }
+
+      if (pathname.startsWith('/options/') && request.method === 'PUT') {
+        const id = pathname.split('/')[2];
+        const { name } = await request.json();
+        let options = await getOptions();
+        const idx = options.findIndex(o => o.id === id);
+        if (idx === -1) return jsonResponse({ error: 'Not found' }, { status: 404 });
+        options[idx].name = name || options[idx].name;
+        await kv.put('options', JSON.stringify(options));
+        return jsonResponse(options[idx]);
+      }
+
+      if (pathname.startsWith('/options/') && request.method === 'DELETE') {
+        const id = pathname.split('/')[2];
+        let options = await getOptions();
+        options = options.filter(o => o.id !== id);
+        await kv.put('options', JSON.stringify(options));
+        return jsonResponse({ success: true });
+      }
+
+      if (pathname === '/sessions' && request.method === 'POST') {
+        const id = crypto.randomUUID();
+        const session = { id, votes: {}, voters: {} };
+        await kv.put(`session:${id}`, JSON.stringify(session), { expirationTtl: 86400 });
+        return jsonResponse({ id }, { status: 201 });
+      }
+
+      if (pathname.match(/^\/sessions\/[^/]+\/vote$/) && request.method === 'POST') {
+        const id = pathname.split('/')[2];
+        const { optionId, userId } = await request.json();
+        if (!optionId || !userId) return jsonResponse({ error: 'optionId and userId required' }, { status: 400 });
+        const data = await kv.get(`session:${id}`);
+        if (!data) return jsonResponse({ error: 'Session not found' }, { status: 404 });
+        const session = JSON.parse(data);
+        if (session.voters[userId]) return jsonResponse({ error: 'Already voted' }, { status: 400 });
+        session.voters[userId] = optionId;
+        session.votes[optionId] = (session.votes[optionId] || 0) + 1;
+        await kv.put(`session:${id}`, JSON.stringify(session), { expirationTtl: 86400 });
+        return jsonResponse(session);
+      }
+
+      if (pathname.match(/^\/sessions\/[^/]+\/results$/) && request.method === 'GET') {
+        const id = pathname.split('/')[2];
+        const data = await kv.get(`session:${id}`);
+        if (!data) return jsonResponse({ error: 'Session not found' }, { status: 404 });
+        const session = JSON.parse(data);
+        return jsonResponse(session.votes);
+      }
+
+      return jsonResponse({ error: 'Not found' }, { status: 404 });
+    } catch (err) {
+      return jsonResponse({ error: err.message }, { status: 500 });
+    }
+  }
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,7 @@
 name = "forkit"
 compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat_v2"]
-main = "workers/session-api.mjs"
+main = "workers/voting-api.mjs"
 
 # Specify that we're using ES modules
 


### PR DESCRIPTION
## Summary
- support Google sign-in that stores email
- add pages for profile, lunch options, and simple vote page
- implement worker API for options and voting
- route through new pages
- update wrangler to use new worker

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6845ca8d40e0832284b7fa8969378606